### PR TITLE
Fix alarm menu option overflowing

### DIFF
--- a/components/GameEventTableCell.tsx
+++ b/components/GameEventTableCell.tsx
@@ -101,7 +101,7 @@ const GameEventTableCell = (props: CellProps): React.ReactElement => {
       </div>
       <ul
         tabIndex={0}
-        className="dropdown-content menu rounded-box top-0 right-0 w-52 bg-base-300 p-2 text-sm shadow"
+        className="min-w-52 dropdown-content menu rounded-box top-0 right-0 bg-base-300 p-2 text-sm shadow"
       >
         {[945, 946, 947, 948, 949, 950, 951].includes(
           Number(gameEvent.gameEvent.id)


### PR DESCRIPTION
before:
<img width="237" alt="Screen Shot 2022-03-25 at 1 10 42 PM" src="https://user-images.githubusercontent.com/2895015/160194324-23671a3f-7d47-4dd6-bc3d-00b7463d2503.png">

after:
<img width="248" alt="Screen Shot 2022-03-25 at 1 10 55 PM" src="https://user-images.githubusercontent.com/2895015/160194332-30f576fd-7589-4832-9b95-0b99a2bd5c89.png">

