### PR TITLE
Allow grouping more event types

### DIFF
--- a/common/GameEvent.ts
+++ b/common/GameEvent.ts
@@ -7,6 +7,7 @@ class GameEvent {
   uuid: string
   times: Array<Interval> = []
   disabled: DateTime | null = null
+  groupName: string | null = null
   constructor(et: APIEventType, ge: APIGameEvent) {
     this.eventType = et
     this.gameEvent = ge

--- a/components/GameEventTableCell.tsx
+++ b/components/GameEventTableCell.tsx
@@ -74,10 +74,8 @@ const GameEventTableCell = (props: CellProps): React.ReactElement => {
         <div className="basis-11/12 items-center font-sans text-xs font-semibold">
           <div className="ml-2 mr-4">
             <span className="block uppercase ">
-              [{gameEvent.gameEvent.minItemLevel}]{' '}
-              {hideGrandPrix && Number(gameEvent.gameEvent.id) === 945
-                ? gameEvent.gameEvent.name.split(' ').slice(0, -1).join(' ')
-                : gameEvent.gameEvent.name}
+              {!(hideGrandPrix && gameEvent.groupName) && `[${gameEvent.gameEvent.minItemLevel}] `}
+              {hideGrandPrix && gameEvent.groupName || gameEvent.gameEvent.name}
               <span className="float-right text-amber-500 dark:text-amber-200">
                 {gameEvent.disabled
                   ? null

--- a/components/modals/AlarmConfigModal.tsx
+++ b/components/modals/AlarmConfigModal.tsx
@@ -96,7 +96,7 @@ const AlarmConfigModal = (props: ConfigModalProps) => {
               </label>
               <label className="label mr-2 cursor-pointer">
                 <span className="label-text w-4/5 text-right font-semibold">
-                  Hide Repeat Events [Grand Prix]
+                  Group Repeat Events <span title="Combine all instances of Grand Prix, Field Bosses, Chaos Gates, and Ghost Ships into single events">[?]</span>
                 </span>
                 <input
                   type="checkbox"

--- a/pages/alarms.tsx
+++ b/pages/alarms.tsx
@@ -41,6 +41,23 @@ const eventIDNameMapping: Array<APIGameEvent> = Object.entries(
   const [id, [name, url, iLvl]] = e as EventIdMapping
   return new APIGameEvent(id, name, url, iLvl)
 })
+
+const groupedEvents = {
+    "Arkesia Grand Prix": eventIDNameMapping
+        .filter(({name}) => name.includes("Grand Prix"))
+        .map(e => e.id),
+    "Field Bosses": eventIDNameMapping
+        .filter(({iconUrl}) => iconUrl === "achieve_14_142.webp")
+        .map(e => e.id),
+    "Chaos Gates": eventIDNameMapping
+        .filter(({iconUrl}) => iconUrl === "achieve_13_11.webp")
+        .sort((a,b) => b.minItemLevel - a.minItemLevel) // this is a bit of a hack to use one of the hourly gates as the canonical one
+        .map(e => e.id),
+    "Ghost Ships": eventIDNameMapping
+        .filter(({name}) => name.includes("Ghost Ship"))
+        .map(e => e.id),
+}
+
 const eventTypeIconMapping: Array<APIEventType> =
   require('../data/msgs.json')[0].map(
     (e: EventTypeIconMapping, idx: number) => {
@@ -292,7 +309,6 @@ const Alarms: NextPage = () => {
   const generateEventsTable = (eventType: number) => {
     // let allEvents: Array<GameEvent> = []
     let ms = Duration.fromObject({ minutes: notifyInMins }).toMillis()
-    let grandPrixEvents = [946, 947, 948, 949, 950, 951]
     let disabledAlarmsKeys = Object.keys(disabledAlarms || {})
 
     let currEventsTable: Array<GameEvent> = []
@@ -311,8 +327,16 @@ const Alarms: NextPage = () => {
         allEventsTable.push(event)
         continue
       }
-      if (hideGrandPrix && grandPrixEvents.includes(Number(event.gameEvent.id)))
-        continue
+
+      if (hideGrandPrix) {
+          const group = Object.entries(groupedEvents)
+              .map(([name, ids]) => ({idx: ids.indexOf(event.gameEvent.id), name}))
+              .filter(({idx}) => idx >= 0)[0]
+          if(group) {
+              if(group.idx > 0) continue
+              event.groupName = group.name
+          }
+      }
 
       let latest = event.latest(serverTime)
       if (latest) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->
Currently the "hide repeat events" feature only applies to Grand Prix.

## What is the new behavior?

This PR expands grouping to also cover the other repeat events: Field Bosses, Chaos Gates, and Ghost Ships.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I used the existing localstorage preference to keep people's existing setting and not have to worry about migration. This could alternatively be its own preference, but that feels a bit heavy. 

I did not update the popup menus on other repeated events. Its doable it just requires tagging all groupable events further. It's probably simpler to just drop this option and have people configure that in settings, but that depends how much you value this option in the popup.