### PR TITLE
24 Hour Merchant Timers

### DIFF
--- a/components/MerchantTableCell.tsx
+++ b/components/MerchantTableCell.tsx
@@ -154,12 +154,18 @@ const MerchantTableCell = (props: CellProps): React.ReactElement => {
                       minute: 30,
                     })
                     .setZone(localizedTZ)
-                    .toLocaleString(DateTime.TIME_SIMPLE)}{' '}
+                    .toLocaleString(view24HrTime 
+                      ? DateTime.TIME_24_SIMPLE 
+                      : DateTime.TIME_SIMPLE
+                    )}{' '}
                   -{' '}
                   {serverTime
                     .set({ minute: 55 })
                     .setZone(localizedTZ)
-                    .toLocaleString(DateTime.TIME_SIMPLE)}
+                    .toLocaleString(view24HrTime
+                      ? DateTime.TIME_24_SIMPLE
+                      : DateTime.TIME_SIMPLE
+                    )}
                 </span>
               ) : null}
             </span>
@@ -211,7 +217,9 @@ const MerchantTableCell = (props: CellProps): React.ReactElement => {
               .nextSpawnTime(serverTime)
               ?.start.setZone(localizedTZ)
               .toLocaleString(
-                view24HrTime ? DateTime.TIME_24_SIMPLE : DateTime.TIME_SIMPLE
+                view24HrTime 
+                  ? DateTime.TIME_24_SIMPLE 
+                  : DateTime.TIME_SIMPLE
               )}
             <span
               className={classNames(

--- a/components/modals/AlarmConfigModal.tsx
+++ b/components/modals/AlarmConfigModal.tsx
@@ -116,7 +116,7 @@ const AlarmConfigModal = () => {
             <div className="w-full">
               <label className="label mr-2 cursor-pointer">
                 <span className="label-text w-4/5 text-right font-semibold">
-                  {t('view-in-24-hr')}
+                  {t('common:view-in-24-hr')}
                 </span>
                 <input
                   type="checkbox"

--- a/components/modals/MerchantConfigModal.tsx
+++ b/components/modals/MerchantConfigModal.tsx
@@ -50,7 +50,7 @@ const MerchantConfigModal = () => {
         <div className="modal-box p-0">
           <div className="w-full bg-base-200 p-2">
             <h3 className="text-center text-lg font-bold uppercase">
-              Settings
+              {t('merchant-settings')}
             </h3>
           </div>
           <div className="flex flex-row space-x-4 p-4">
@@ -83,6 +83,21 @@ const MerchantConfigModal = () => {
                   className="checkbox checkbox-sm"
                 />
               </label>
+            </div>
+            <div className="w-full">
+              <label className="label mr-2 cursor-pointer">
+                <span className="label-text w-4/5 text-right font-semibold">
+                  {t('common:view-in-24-hr')}
+                </span>
+                <input
+                  type="checkbox"
+                  onClick={(e) =>
+                    setView24HrTime((e.target as HTMLInputElement).checked)
+                  }
+                  defaultChecked={view24HrTime}
+                  className="checkbox checkbox-sm"
+                />
+              </label>
               <label className="label mr-2 cursor-pointer">
                 <span className="label-text w-4/5 text-right font-semibold">
                   {t('common:view-in-current-time')}
@@ -97,7 +112,6 @@ const MerchantConfigModal = () => {
                 />
               </label>
             </div>
-            <div className="w-full"></div>
           </div>
           <div className="modal-action mb-5 justify-center">
             <label

--- a/pages/merchants.tsx
+++ b/pages/merchants.tsx
@@ -175,6 +175,7 @@ const Merchants: NextPage = (props) => {
     )
   }, [
     regionTZName,
+    view24HrTime,
     viewLocalizedTime,
     selectedServer,
     wanderingMerchants,

--- a/pages/merchants.tsx
+++ b/pages/merchants.tsx
@@ -304,7 +304,9 @@ const Merchants: NextPage = (props) => {
                   <div className="absolute right-5 top-7">
                     {t('last-updated')}:{' '}
                     {dataLastRefreshed.toLocaleString(
-                      DateTime.TIME_WITH_SECONDS
+                      view24HrTime
+                        ? DateTime.TIME_24_WITH_SECONDS
+                        : DateTime.TIME_WITH_SECONDS
                     )}
                   </div>
                 </td>

--- a/public/locales/en/alarmConfig.json
+++ b/public/locales/en/alarmConfig.json
@@ -4,7 +4,6 @@
   "hide-disabled-events": "Hide Disabled Events",
   "group-repeat-events": "Group Repeat Events",
   "reset-disabled-events": "Reset Disabled Events",
-  "view-in-24-hr": "View in 24HR",
   "alert-sound": "Alert Sound",
   "muted": "Muted"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3,6 +3,7 @@
   "merchant-link-text": "Merchants",
   "current-time": "Current Time",
   "server-time": "Server Time",
+  "view-in-24-hr": "View in 24HR",
   "option-minute-before": "{{minutes}} min before",
   "view-in-current-time": "View in Current Time",
   "all-done": "All Done"

--- a/public/locales/zh/alarmConfig.json
+++ b/public/locales/zh/alarmConfig.json
@@ -4,7 +4,6 @@
   "hide-disabled-events": "隐藏禁用的事件",
   "group-repeat-events": "隐藏重复的事件 [大奖赛]",
   "reset-disabled-events": "重置禁用的事件",
-  "view-in-24-hr": "查看24小时内的",
   "alert-sound": "提醒声音",
   "muted": "静音"
 }

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -3,6 +3,7 @@
   "merchant-link-text": "流浪商人",
   "current-time": "当前时间",
   "server-time": "服务器时间",
+  "view-in-24-hr": "查看24小时内的",
   "option-minute-before": "提前{{minutes}}分钟提醒",
   "view-in-current-time": "当前时间内查看",
   "all-done": "确定"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
* Users are unable to toggle between 12/24 hour formats from within the Merchant settings modal. This provides an inconsistent user experience for users who don't know the setting is under the Alarms settings modal
* The Settings header in the Merchants modal is hardcoded in English. Translators may wish to have this text translated in the future (issue not present in the Alarms modal)

Issue URL: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Improved consistency between the Alarm and Merchant setting modals
  - Added a 12/24 hour toggle to the Merchant setting modal
  - Changed the heading found in the Merchant setting modal to respect locale settings
  - Moved the toggle for local (current)/server time to the same spot so that it matches the position found in the Alarm modal
  - Moved the `view-in-24-hr` string from `public/locales/[en,zh]/alarmConfig.json` to `public/locales/[en,zh]/common.json`. Updated the locale text found in both `AlarmConfigModal.tsx` and `MerchantConfigModal.tsx` to reflect this change
- Updated the tables to immediately switch between 12/24 hour formats when requested from the user
  - Affected fields: Last-Updated, Current Timeframe (when the merchant is currently active), Next Spawn 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
This PR aims to change how time is presented to the user. No impact to operations are expected.

## Other information

### Modal Changes
Comparison of the current live models
![CurrentModal](https://user-images.githubusercontent.com/28322630/167061016-221d98e0-0430-4f76-93fe-c1a2e75a8d7f.png)

Comparison of the changed models in this PR
![ModifiedModal](https://user-images.githubusercontent.com/28322630/167061022-e9758465-4793-4feb-998e-1a61a08317c2.png)

### 12/24 Hour Changes
Affected areas when configured to 12 hour format
![12hrSetting](https://user-images.githubusercontent.com/28322630/167075741-330eb7e2-0a2d-4ffe-8ae0-134c092cd0f0.png)

Affected areas when configured to 24 hour format
![24hrSetting](https://user-images.githubusercontent.com/28322630/167075830-298880c5-d325-4373-830f-e7285e389108.png)

