### PR TITLE
Added button to disable all alarms

### DIFF
--- a/components/modals/AlarmConfigModal.tsx
+++ b/components/modals/AlarmConfigModal.tsx
@@ -4,6 +4,7 @@ import { alert1, alert2, alert3, alert4, alert5, alert6 } from '../../sounds'
 import useLocalStorage from '@olerichter00/use-localstorage'
 import { IconVolume2, IconVolume3 } from '@tabler/icons'
 import { useTranslation } from 'next-i18next'
+import { DateTime } from 'luxon'
 
 const sounds = {
   'Alert 1': alert1,
@@ -54,6 +55,18 @@ const AlarmConfigModal = () => {
   const [disabledAlarms, setDisabledAlarms] = useLocalStorage<{
     [key: string]: number
   }>('disabledAlarms', {})
+  const disableAllAlarms = () => {
+    Object.entries(
+      require('../../data/events.json')
+    ).forEach((e) => {
+      const [id] = e;
+      disabledAlarms[id] = DateTime.now().plus({ hours: 336 }).toMillis();
+      
+      setDisabledAlarms({
+        ...disabledAlarms,
+      });
+    })
+  }
   const [volume, setVolume] = useLocalStorage('volume', 0.4)
   return (
     <>
@@ -117,6 +130,14 @@ const AlarmConfigModal = () => {
                   onClick={(e) => setDisabledAlarms({})}
                 >
                   {t('reset-disabled-events')}
+                </button>
+              </div>
+              <div className="flex w-full items-center">
+                <button
+                  className="btn btn-error btn-xs mx-auto mt-2"
+                  onClick={(e) => disableAllAlarms()}
+                >
+                  {t('disable-all-events')}
                 </button>
               </div>
             </div>

--- a/public/locales/en/alarmConfig.json
+++ b/public/locales/en/alarmConfig.json
@@ -6,5 +6,6 @@
   "reset-disabled-events": "Reset Disabled Events",
   "alert-sound": "Alert Sound",
   "muted": "Muted",
-  "enable-desktop-notifications": "Enable Desktop Notifications"
+  "enable-desktop-notifications": "Enable Desktop Notifications",
+  "disable-all-events": "Disable All Events"
 }


### PR DESCRIPTION
Added a new a new button to disable all alarms. Sometimes I'm only interested in a few events, and it's easier to disable all the alarms and then add ones that I need one by one.


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Build (`npm run build`) was run locally and any changes were pushed

## Pull request type

Please check the type of change your PR introduces:

- [X] Feature

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
![image](https://user-images.githubusercontent.com/3864402/180665289-2a5c1f67-1435-4e92-bdd9-8945200f4d3a.png)

