### PR TITLE
Automatic Daylight Saving and Date Adjustments

### DIFF
--- a/pages/alarms.tsx
+++ b/pages/alarms.tsx
@@ -120,7 +120,7 @@ const Alarms: NextPage = () => {
   const [serverTime, setServerTime] = useState<DateTime>(
     currDate.setZone(regionTZ)
   )
-  const [selectedDate, setSelectedDate] = useState(currDate.set({hour: 0, minute: 0, second: 0, millisecond: 0}).setZone(regionTZ))
+  const [selectedDate, setSelectedDate] = useState(currDate.setZone(regionTZ).set({hour: 0, minute: 0, second: 0, millisecond: 0}))
 
   const [gameEvents, setGameEvents] = useState<Array<GameEvent> | undefined>(
     undefined

--- a/pages/alarms.tsx
+++ b/pages/alarms.tsx
@@ -120,7 +120,7 @@ const Alarms: NextPage = () => {
   const [serverTime, setServerTime] = useState<DateTime>(
     currDate.setZone(regionTZ)
   )
-  const [selectedDate, setSelectedDate] = useState(currDate.setZone(regionTZ))
+  const [selectedDate, setSelectedDate] = useState(currDate.set({hour: 0, minute: 0, second: 0, millisecond: 0}).setZone(regionTZ))
 
   const [gameEvents, setGameEvents] = useState<Array<GameEvent> | undefined>(
     undefined
@@ -185,7 +185,7 @@ const Alarms: NextPage = () => {
     if (regionTZ !== undefined) {
       setMounted(true)
       setServerTime(currDate.setZone(regionTZ))
-      setSelectedDate(currDate.setZone(regionTZ))
+      setSelectedDate(currDate.setZone(regionTZ).set({hour: 0, minute: 0, second: 0, millisecond: 0}))
     }
   }, [regionTZ])
 
@@ -200,14 +200,14 @@ const Alarms: NextPage = () => {
   useEffect(() => {
     const timer = setInterval(() => {
       let now = DateTime.now()
-      if (currDate.endOf('day').diffNow().toMillis() < 0) setSelectedDate(now)
+      if (serverTime.endOf('day').diffNow().toMillis() < 0) setSelectedDate(now.setZone(regionTZ).set({hour: 0, minute: 0, second: 0, millisecond: 0}))
       setCurrDate(now)
       setServerTime(now.setZone(regionTZ))
     }, 1000)
     return () => {
       clearInterval(timer) // Return a function to clear the timer so that it will stop being called on unmount
     }
-  }, [regionTZ, view24HrTime, viewLocalizedTime, selectedDate])
+  }, [regionTZ, view24HrTime, viewLocalizedTime, selectedDate, serverTime.day])
 
   // clear disabled alarm when alarm expires
   useEffect(() => {
@@ -539,7 +539,7 @@ const Alarms: NextPage = () => {
             </button>
             <button
               className="btn relative text-2xl text-stone-200"
-              onClick={(e) => setSelectedDate(serverTime)}
+              onClick={(e) => setSelectedDate(serverTime.setZone(regionTZ).set({hour: 0, minute: 0, second: 0, millisecond: 0}))}
             >
               <span>
                 {selectedDate.monthLong} {selectedDate.day}

--- a/util/static.ts
+++ b/util/static.ts
@@ -11,7 +11,7 @@ import { DateTime } from 'luxon'
 
 function DSTOffset(IANAString: string): string {
   const offset = DateTime.now().setZone(IANAString).get('offset') / 60 || 0;
-  return (`UTC${offset > 0 ? "+" + offset : offset !== 0 ? offset : ''}`); // UTC+offset, UTC-offset, UTC
+  return (`UTC${offset >= 0 ? "+" + offset : offset}`); // UTC+offset, UTC-offset
 }
 
 export const RegionTimeZoneMapping: { [K in RegionKey]: string } = {

--- a/util/static.ts
+++ b/util/static.ts
@@ -4,8 +4,8 @@ import { DateTime } from 'luxon'
 /* IANA Codes relative to approximate AWS server locations, as per http://ec2-reachability.amazonaws.com/
   NA East: America/New_York (Herndon, VA, US)
   NA West: America/Los_Angeles (San Francisco, CA, US)
-  EU West: Europe/Dublin (Dublin, Ireland)
   EU Central: Europe/Berlin (Frankfurt, Germany)
+  EU West: Europe/Dublin (Dublin, Ireland)
   South America: America/Sao_Paulo (São Paulo, Brazil)
 */
 

--- a/util/static.ts
+++ b/util/static.ts
@@ -17,7 +17,7 @@ function DSTOffset(IANAString: string): string {
 export const RegionTimeZoneMapping: { [K in RegionKey]: string } = {
   'US West': DSTOffset('America/Los_Angeles'),
   'US East': DSTOffset('America/New_York'),
-  'EU Central': DSTOffset('Europe/Dublin'),
-  'EU West': DSTOffset('Europe/Berlin'),
+  'EU Central': DSTOffset('Europe/Berlin'),
+  'EU West': DSTOffset('Europe/Dublin'),
   'South America': DSTOffset('America/Sao_Paulo'),
 }

--- a/util/static.ts
+++ b/util/static.ts
@@ -10,8 +10,8 @@ import { DateTime } from 'luxon'
 */
 
 function DSTOffset(IANAString: string): string {
-  const offset = DateTime.now().setZone(IANAString).get('offset') / 60 || 0;
-  return (`UTC${offset >= 0 ? "+" + offset : offset}`); // UTC+offset, UTC-offset
+  const offset = DateTime.now().setZone(IANAString).get('offset') / 60 || 0
+  return (`UTC${offset >= 0 ? "+" + offset : offset}`) // UTC+offset, UTC-offset
 }
 
 export const RegionTimeZoneMapping: { [K in RegionKey]: string } = {

--- a/util/static.ts
+++ b/util/static.ts
@@ -1,9 +1,23 @@
 import { RegionKey } from './types/types'
+import { DateTime } from 'luxon'
+
+/* IANA Codes relative to approximate AWS server locations, as per http://ec2-reachability.amazonaws.com/
+  NA East: America/New_York (Herndon, VA, US)
+  NA West: America/Los_Angeles (San Francisco, CA, US)
+  EU West: Europe/Dublin (Dublin, Ireland)
+  EU Central: Europe/Berlin (Frankfurt, Germany)
+  South America: America/Sao_Paulo (São Paulo, Brazil)
+*/
+
+function DSTOffset(IANAString: string): string {
+  const offset = DateTime.now().setZone(IANAString).get('offset') / 60 || 0;
+  return (`UTC${offset > 0 ? "+" + offset : offset !== 0 ? offset : ''}`); // UTC+offset, UTC-offset, UTC
+}
 
 export const RegionTimeZoneMapping: { [K in RegionKey]: string } = {
-  'US West': 'UTC-7',
-  'US East': 'UTC-4',
-  'EU Central': 'UTC+1',
-  'EU West': 'UTC-0',
-  'South America': 'UTC-4',
+  'US West': DSTOffset('America/Los_Angeles'),
+  'US East': DSTOffset('America/New_York'),
+  'EU Central': DSTOffset('Europe/Dublin'),
+  'EU West': DSTOffset('Europe/Berlin'),
+  'South America': DSTOffset('America/Sao_Paulo'),
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
* The `RegionTimeZoneMapping` variable is manually updated some time after Daylight Saving occurs for NA and EU servers, which unfortunately occurs on different Sundays (2nd/1st Sundays of March/Nov respectively for NA, and last Sundays of March and Oct for EU). South American servers are most likely not affected by DST.

* Users looking at events happening the following day after the page loads will always initially be told that events are happening "in 23 hours". This is because time is calculated relative to when the user initially accessed the page.
* The automatic date changer changes dates when the local current time hits midnight. Users living in time zones that do not line up with the selected server's time zone may experience unexpected behavior when either the local or server date changes. <br/>Note that these issues can currently be resolved manually by clicking on the date button, or by refreshing the page
  * Users with local times that changes the date ahead of the server will have events skipped
  * If the server changes the date ahead of the user's local time, the date will not automatically change and new events are not shown

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
**Improved automation**
- Changed the dropdowns to now automatically adjust based on whether the server's time zone has experienced Daylight Saving. Server locations are based on the assumption of the IANA TZ database codes from the [AWS EC2 server host cities](http://ec2-reachability.amazonaws.com/). This improves resiliency in case future legislation is enacted to modify DST for those cities.
- Changed the selected date's reference point to midnight server time
- The automatic date changer will now switch dates when the server does

## Does this introduce a breaking change?

- [ ] Yes
- [x] No